### PR TITLE
Fix messages

### DIFF
--- a/src/device/device_usb.cpp
+++ b/src/device/device_usb.cpp
@@ -32,8 +32,8 @@ control_ret_t Device::device_init()
                 cerr << "Device (USB)::device_init() -- Found device VID: " << device_info[offset+1] << " PID: " << device_info[offset+2] << " interface: " << device_info[offset+3] << endl;
                 break;
             }
+            cerr << "Device (USB)::device_init() -- No device found" << endl;
         }
-        cerr << "Device (USB)::device_init() -- No device found" << endl;
     }
     else
     {

--- a/src/device/device_usb.cpp
+++ b/src/device/device_usb.cpp
@@ -29,7 +29,7 @@ control_ret_t Device::device_init()
             if(ret == CONTROL_SUCCESS)
             {
                 device_initialised = true;
-                cerr << "Device (USB)::device_init() -- Found device VID: " << device_info[offset+1] << " PID: " << device_info[offset+2] << " interface: " << device_info[offset+3] << endl;
+                cout << "Device (USB)::device_init() -- Found device VID: " << device_info[offset+1] << " PID: " << device_info[offset+2] << " interface: " << device_info[offset+3] << endl;
                 break;
             }
             cerr << "Device (USB)::device_init() -- No device found" << endl;


### PR DESCRIPTION
Send the 'device found' message to cout instead of cerr.  Only print the 'no device found' message if, in fact, no device is found.

Part of VFH-117.