### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Host XVF Control change log
 ===========================
 
+3.0.0
+-----
+
+  * CHANGED: Structure of ``device_info`` array
+  * ADDED: Support for additional sets of USB device information in ``device_info``
+  * CHANGED: Minor CLI documentation updates for ``xvf_dfu``
+  * CHANGED: ``xvf_dfu`` now raises an exception if attempting to use any other protocol than I2C.
+
 2.1.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -15,11 +15,19 @@ Some dependent components are included as git submodules. These can be obtained 
 
     git clone --recurse-submodules git@github.com:xmos/xvf_host_control.git
 
+************
+Requirements
+************
+
+- CMake 3.13 or later
+- Visual Studio 2022 Tools (Windows only)
+- Ninja (Windows only)
+
 ********
 Building
 ********
 
-Build with cmake from the host_xvf_control/ folder:
+Build with CMake from the host_xvf_control/ folder:
 
 - on Linux and Mac
 
@@ -36,13 +44,17 @@ Build with cmake from the host_xvf_control/ folder:
 
 .. note::
 
-    Windows drivers can only be built with 32-bit tools
+    Windows drivers can only be built with 32-bit tools.
+
+.. note::
+
+    Windows drivers are currently supported only for *Visual Studio 2022 Tools*. If a different toolchain is required, the static *libusb* library should be built and linked manually. More details can be found in fwk_rtos//modules/sw_services/device_control/host/libusb/Win32/README.md.
 
 *****
 Using
 *****
 
-In order to use the host control application you should have the following files in the same location:
+In order to use the host control application place the following files in the same location:
 
 - xvf_host(.exe)
 - (lib)command_map.(so/dll/dylib)
@@ -54,7 +66,8 @@ In order to use the host control application you should have the following files
     - Apple dynamic libraries end with ``.dylib``
     - Windows dynamic libraries don't have ``lib`` prefix and end with ``.dll``
 
-The application and the device drivers can be obtained by following the build instructions of this repo. Command map is a part of the firmware code and built separately.
+The application and the device drivers can be obtained by following the build instructions of this repo. 
+The command map is a part of the firmware code and built separately; see relevant documentation for the target for instructions on how to build and combine the command map.
 To find out use cases and more information about the application use:
 
 - on Linux and Mac
@@ -76,7 +89,7 @@ The DFU host application is only supported on Raspbian, and it needs the followi
 - dfu_cmds.yaml
 - transport_config.yaml
 
-If you need to change the settings of the I2C and SPI transport protocols, all the configurable values are listed in *src/dfu/transport_config.yaml*.
+To change the settings of the I2C and SPI transport protocols, edit the configurable values listed in *src/dfu/transport_config.yaml*.
 
 *****************************************
 Supported platforms and control protocols

--- a/src/device/device_usb.cpp
+++ b/src/device/device_usb.cpp
@@ -13,11 +13,35 @@ Device::Device(int * info)
 
 control_ret_t Device::device_init()
 {
-    control_ret_t ret = CONTROL_SUCCESS;
+    control_ret_t ret = CONTROL_ERROR;
     if(!device_initialised)
     {
-        ret = control_init_usb(static_cast<int>(device_info[0]), static_cast<int>(device_info[1]), static_cast<int>(device_info[2]));
-        device_initialised = true;
+        // The USB device information list has a peculiar structure.
+        // It consists of multiple sets.
+        // Each set has three members, a VID, a PID, and the number of the USB control interface.
+        // These three members appear in the order given above.
+        // To allow the count of sets to change in future, the zero-th element in the list holds a count of how many sets follow.
+        int info_set_count = static_cast<int>(device_info[0]);
+        for(int set_idx = 0; set_idx < info_set_count; ++set_idx)
+        {
+            int offset = set_idx * 3; // Three members per set
+            ret = control_init_usb(static_cast<int>(device_info[offset+1]), static_cast<int>(device_info[offset+2]), static_cast<int>(device_info[offset+3]));
+            if(ret == CONTROL_SUCCESS)
+            {
+                device_initialised = true;
+                cout << "Device (USB)::device_init() -- Found device VID: " << device_info[offset+1] << " PID: " << device_info[offset+2] << " interface: " << device_info[offset+3] << endl;
+                break;
+            }
+        }
+        if (ret != CONTROL_SUCCESS)
+        {
+            cerr << "Device (USB)::device_init() -- No device found" << endl;
+        }
+    }
+    else
+    {
+        cerr << "Device (USB)::device_init() -- Device already initialised" << endl;
+        ret = CONTROL_SUCCESS;
     }
     return ret;
 }

--- a/src/dfu/dfu_main.cpp
+++ b/src/dfu/dfu_main.cpp
@@ -10,7 +10,7 @@ using namespace std;
 opt_t options[] = {
     {"--help",                    "-h",        "display this information"                                                                                           },
     {"--app-version",             "-av",       "print the version of this application",                                                                             },
-    {"--use",                     "-u",        "use specific hardware protocol, I2C, SPI and USB are available to use"                                              },
+    {"--use",                     "-u",        "use specific hardware protocol, only I2C is currently supported" },
     {"--verbose",                 "-vvv",      "enable debug prints"                                                                                                },
     {"--upload-start",            "-us",       "set the first block transport number for the upload operation. Default is 0. Option valid only with upload commands"},
     {"--version",                 "-v",        "read the version on the device",                                                                                    },
@@ -59,8 +59,7 @@ control_ret_t print_help_menu()
     // Please avoid lines which have more than 80 characters
     cout << "usage: xvf_dfu [ -u <protocol> ] command" << endl
     << endl << "Current application version is " << current_host_app_version << "."
-    << endl << "You can use --use or -u option to specify protocol you want to use."
-    << endl << "Default control protocol is I2C."
+    << endl << "Only control over I2C is supported."
     << endl << endl << "Options:" << endl;
     for(opt_t opt : options)
     {
@@ -152,6 +151,11 @@ int main(int argc, char ** argv)
 
     // Check if --use option is used
     string device_dl_name = get_device_lib_name(&argc, argv, options, num_options);
+    if (device_dl_name != device_i2c_dl_name) {
+        cerr << "Unsupported hardware protocol. Only I2C is available for this operation." << endl;
+        exit(HOST_APP_ERROR);
+    }
+
 
     // Check other optional arguments
     uint8_t is_verbose = check_verbose(&argc, argv);

--- a/src/host_drivers.cmake
+++ b/src/host_drivers.cmake
@@ -55,7 +55,7 @@ target_include_directories(device_i2c
         ${DEVICE_CONTROL_PATH}/host
 )
 target_link_libraries(device_i2c
-    PUBLIC  
+    PUBLIC
         rtos::sw_services::device_control_host_i2c
 )
 target_link_options(device_i2c PRIVATE -fPIC)
@@ -73,7 +73,7 @@ target_include_directories(device_spi
         ${DEVICE_CONTROL_PATH}/host
 )
 target_link_libraries(device_spi
-    PUBLIC  
+    PUBLIC
         rtos::sw_services::device_control_host_spi
 )
 target_link_libraries(device_spi PRIVATE -fPIC)
@@ -101,7 +101,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     add_compile_definitions(nologo WAll WX- O2 EHa)
     target_link_directories(framework_rtos_sw_services_device_control_host_usb INTERFACE "${DEVICE_CONTROL_PATH}/host/libusb/Win32")
     set(libusb-1.0_INCLUDE_DIRS "${DEVICE_CONTROL_PATH}/host/libusb/Win32")
-    set(LINK_LIBS libusb)
+    set(LINK_LIBS libusb-1.0)
 endif()
 
 target_sources(framework_rtos_sw_services_device_control_host_usb
@@ -145,7 +145,7 @@ target_link_libraries(device_usb PRIVATE -fPIC)
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     add_custom_command(
         TARGET device_usb
-        POST_BUILD 
+        POST_BUILD
         COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change "/usr/local/lib/libusb-1.0.0.dylib" "@executable_path/libusb-1.0.0.dylib" ${CMAKE_BINARY_DIR}/"libdevice_usb.dylib"
     )
     add_custom_command(

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -90,7 +90,7 @@ const std::string default_command_map_name = "command_map";
  *
  * @note This will have to be manually changed after the release
  */
-const std::string current_host_app_version = "2.1.0";
+const std::string current_host_app_version = "3.0.0";
 
 /** @brief Convert string to upper case */
 std::string to_upper(std::string str);


### PR DESCRIPTION
  * CHANGED: Structure of ``device_info`` array
  * ADDED: Support for additional sets of USB device information in ``device_info``
  * CHANGED: Minor CLI documentation updates for ``xvf_dfu``
  * CHANGED: ``xvf_dfu`` now raises an exception if attempting to use any other protocol than I2C.